### PR TITLE
Advisor: Harden storage account webassets-prod (HTTPS-only, TLS1.2, no public blob access)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,31 @@
+// Azure Advisor remediation: harden Storage Account security settings
+// Target: webassets-prod (Microsoft.Storage/storageAccounts)
+// - Enforce HTTPS-only traffic
+// - Require minimum TLS 1.2
+// - Disable public blob access
+
+targetScope = 'resourceGroup'
+
+@description('Name of the Storage Account to configure')
+param storageAccountName string = 'webassets-prod'
+
+@description('Azure region for the Storage Account (must match existing if already deployed)')
+param location string = resourceGroup().location
+
+// NOTE:
+// If the storage account already exists and is managed outside this template,
+// deploying this file may attempt to create it. Prefer importing into IaC or
+// aligning with your existing deployment structure.
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}


### PR DESCRIPTION
This change applies an Azure Advisor-style security hardening for the Storage Account **webassets-prod** by:

- Enforcing HTTPS-only traffic (`supportsHttpsTrafficOnly: true`)
- Requiring minimum TLS 1.2 (`minimumTlsVersion: 'TLS1_2'`)
- Disabling public blob access (`allowBlobPublicAccess: false`)

File changed:
- `infra/main.bicep`

Resource:
- `/subscriptions/a1b2c3d4-1111-4f8a-9c2e-0123456789ab/resourceGroups/web-prod-rg/providers/Microsoft.Storage/storageAccounts/webassets-prod`

> Note: If the storage account already exists and is not currently deployed via this template, you may want to integrate these properties into your existing IaC module for the storage account to avoid accidental create/replace behavior.