### PR TITLE
Advisor: Harden storage account webassets-prod (HTTPS only, disable public blob access, TLS 1.2)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,39 @@
+// Azure Storage Account hardening per Azure Advisor recommendation
+// - Enforce HTTPS-only traffic
+// - Disable public blob access
+// - Require minimum TLS 1.2
+//
+// NOTE: This file is intentionally minimal and can be integrated into your existing IaC structure.
+
+targetScope = 'resourceGroup'
+
+@description('Name of the Storage Account to configure')
+param storageAccountName string = 'webassets-prod'
+
+@description('Location for the Storage Account (must match existing if already deployed)')
+param location string = resourceGroup().location
+
+@description('SKU for the Storage Account')
+param skuName string = 'Standard_LRS'
+
+@description('Kind for the Storage Account')
+param kind string = 'StorageV2'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  kind: kind
+  sku: {
+    name: skuName
+  }
+  properties: {
+    // Advisor: Secure transfer should be enabled
+    supportsHttpsTrafficOnly: true
+
+    // Advisor: Prevent anonymous/public access to blobs/containers
+    allowBlobPublicAccess: false
+
+    // Advisor: Enforce modern TLS
+    minimumTlsVersion: 'TLS1_2'
+  }
+}


### PR DESCRIPTION
Implements a common Azure Advisor security recommendation for Storage Accounts by updating IaC to:

- Enforce HTTPS-only traffic (`supportsHttpsTrafficOnly: true`)
- Disable public blob access (`allowBlobPublicAccess: false`)
- Require minimum TLS 1.2 (`minimumTlsVersion: 'TLS1_2'`)

Target resource:
- /subscriptions/2fa761b0-056f-43b8-8eba-2677199dfb9d/resourceGroups/web-prod-rg/providers/Microsoft.Storage/storageAccounts/webassets-prod
- /subscriptions/69d83c88-2ad6-482b-ad60-3c7fb8791568/resourceGroups/web-prod-rg/providers/Microsoft.Storage/storageAccounts/webassets-prod

Notes:
- This PR creates `infra/main.bicep` (it did not exist in the repo). If you already have an existing Bicep/Terraform structure, you can move these properties into the existing storage account definition.
- Review SKU/kind/location parameters to ensure they match the existing deployed storage account to avoid unintended drift.
